### PR TITLE
Add redmine 5.x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redmine Gitlab Adapter Plugin
 
-For Redmine 3.x.x or Redmine 4.x.x.
+For Redmine 3.4 or above, Redmine 4.x.x, and Redmine 5.x.x.
 
 ### Plugin installation
 

--- a/app/models/repository/gitlab.rb
+++ b/app/models/repository/gitlab.rb
@@ -1,4 +1,4 @@
-require 'redmine/scm/adapters/gitlab_adapter'
+require File.expand_path('../../../../lib/redmine/scm/adapters/gitlab_adapter', __FILE__)
 
 class Repository::Gitlab < Repository
   validates_presence_of :url, :password

--- a/init.rb
+++ b/init.rb
@@ -1,5 +1,5 @@
 require 'redmine'
-require 'gitlab_repositories_helper_patch'
+require File.expand_path('../lib/gitlab_repositories_helper_patch', __FILE__)
 
 Redmine::Plugin.register :redmine_gitlab_adapter do
   name 'Redmine Gitlab Adapter plugin'


### PR DESCRIPTION
## 概要

Redmine 5.x に対応。

## テスト

[動作確認](https://future-architect.github.io/articles/20210908a/#%E5%8B%95%E4%BD%9C%E7%A2%BA%E8%AA%8D)のようなリポジトリ画面が正しく出ることを手動で確認。

### 環境

- Gitlabはクラウド版の16.2
- [redmine公式イメージ](https://hub.docker.com/_/redmine/) の下記バージョン

### 結果

| redmine |  ruby  | result |
| ------- | ------ | ------ |
| 5.0.5   | 3.1.4  | o      |
| 4.2.10  | 2.7.8  | o      |
| 4.0.9   | 2.6.9  | o      |
| 4.0.0   | 2.5.3  | o      |
| 3.4.13  | 2.4.10 | o      |
| 3.4.1   | 2.4.1  | o      |
| 3.3.9   | 2.3.8  | x※      |

## 備考

- ※gem gitlabはruby2.3非対応(String#unpack1は2.4から追加)のため、Redmine3.3で動作しないのは正常(https://rubyreferences.github.io/rubychanges/2.4.html)
- Redmine 3.3はruby2.3までしか対応していないため、redmine3.4以上をサポートするようにREADMEを変更 (https://www.redmine.org/projects/redmine/wiki/RedmineInstall/263)